### PR TITLE
Support composer.lock in path other than root of repo

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,14 +1,18 @@
 name: Dependabot composer diff
 description: Posts a comment with a diff when Composer dependencies are updated
 inputs:
-  token:
+  path_prefix:
     required: true
-    default: ${{ github.token }}
-    description: GitHub token to post the comment with
+    default: ./
+    description: Path where to find the composer.lock file.
   pull_request:
     required: true
     default: ${{ github.event.number }}
     description: The pull request to post the comment to. This defaults to the current PR and should not be changed.
+  token:
+    required: true
+    default: ${{ github.token }}
+    description: GitHub token to post the comment with.
 outputs:
   diff:
     description: The generated diff
@@ -17,4 +21,5 @@ runs:
   image: Dockerfile
   env:
     GITHUB_TOKEN: ${{ inputs.token }}
+    PATH_PREFIX: ${{ inputs.path_prefix }}
     PULL_REQUEST: ${{ inputs.pull_request }}

--- a/action.yaml
+++ b/action.yaml
@@ -1,7 +1,7 @@
 name: Dependabot composer diff
 description: Posts a comment with a diff when Composer dependencies are updated
 inputs:
-  path_prefix:
+  base_path:
     required: true
     default: ./
     description: Path where to find the composer.lock file.
@@ -20,6 +20,6 @@ runs:
   using: docker
   image: Dockerfile
   env:
+    BASE_PATH: ${{ inputs.base_path }}
     GITHUB_TOKEN: ${{ inputs.token }}
-    PATH_PREFIX: ${{ inputs.path_prefix }}
     PULL_REQUEST: ${{ inputs.pull_request }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF}"
 
-DIFF="$(composer-lock-diff --path="${PATH_PREFIX}" --from="origin/${GITHUB_BASE_REF}" --to="${GITHUB_SHA}" --md)"
+DIFF="$(composer-lock-diff --path="${BASE_PATH}" --from="origin/${GITHUB_BASE_REF}" --to="${GITHUB_SHA}" --md)"
 
 outputDiff="${DIFF}"
 outputDiff="${outputDiff//'%'/'%25'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF}"
 
-DIFF="$(composer-lock-diff --from="origin/${GITHUB_BASE_REF}" --to="${GITHUB_SHA}" --md)"
+DIFF="$(composer-lock-diff --path="${PATH_PREFIX}" --from="origin/${GITHUB_BASE_REF}" --to="${GITHUB_SHA}" --md)"
 
 outputDiff="${DIFF}"
 outputDiff="${outputDiff//'%'/'%25'}"


### PR DESCRIPTION
https://github.com/Pararius/frontend for example has a non-standard location of the `composer.*` files currently.